### PR TITLE
Added javascript to remove unnecessary items from the startup checklist.

### DIFF
--- a/js/course_startup_checklist_remove_irrelevant_items.js
+++ b/js/course_startup_checklist_remove_irrelevant_items.js
@@ -1,0 +1,12 @@
+require(['jsx/course_wizard/ListItems'], function(ListItems) {
+    var itemsToRemove = ['add_students', 'add_tas'];
+    var shouldRemoveItem = function(item) {
+        return itemsToRemove.indexOf(item.key) > -1;
+    };
+    var removeIrrelevantItems = function(item, index, listItems) {
+        if (shouldRemoveItem(item)) {
+            listItems.splice(index, 1);
+        }
+    };
+    ListItems.forEach(removeIrrelevantItems);
+});


### PR DESCRIPTION
This PR adds some Javascript that modifies the course checklist page -- it removes the items that prompt teaching staff to add students and TAs to their courses (since those would be fed by the registrar or added some other way).