### PR TITLE
Feature/remove default link underlining for user content a.btn

### DIFF
--- a/css/user_content.css
+++ b/css/user_content.css
@@ -2,3 +2,4 @@
 /* select descendants of .user_content to avoid overriding Canvas native      */
 /* a.btn elements                                                             */
 .user_content a.btn { text-decoration: none; }
+.user_content a.btn span { text-decoration: none; }

--- a/css/user_content.css
+++ b/css/user_content.css
@@ -1,0 +1,4 @@
+/* templates use a.btn, which Canvas displays with text-decoration:underline  */
+/* select descendants of .user_content to avoid overriding Canvas native      */
+/* a.btn elements                                                             */
+.user_content a.btn { text-decoration: none; }


### PR DESCRIPTION
# Expected behavior
Custom buttons, e.g. on [theme page](https://harvard.beta.instructure.com/courses/19582), do not show (link) underline styles, even when hovering.

# Background
The Dec 10 production release notes in the [Rich Content Editor section](https://community.canvaslms.com/docs/DOC-8610#jive_content_id_Rich_Content_Editor), down in the Underlined Hyperlinks sub-section, describe how all anchor links on pages served by Canvas will now show underline styling. This is presumably for accessibility and consistency.

HLS uses custom 'buttons' on their templates which actually are anchor links using `.btn` styling to make them look like buttons. HLS would like to remove the link underlining in this case; see [INC02024841](https://harvard.service-now.com/nav_to.do?uri=incident.do?sysparm_query=number=INC02024841).

This PR attempts to remove all underlining affecting the `a.btn` 'buttons' anywhere inside user-generated content spaces (it should not affect Canvas buttons as well, which appear to be `button` elements, not `a` elements).

# Alternatives
Another approach would be for HLS to use custom classes, like `.hls-btn-link`, which could further narrow the element selection filter, but this would require HLS to do more work on their pages and style guides, and they would like to make the change as soon as possible.

From a UX/accessibility point of view we may want to review whether this is the best long-term approach as well.

# Supersedes
PR #10

@dbreidenbach-hls
